### PR TITLE
Correct URL for PyPi

### DIFF
--- a/inputimeout/__version__.py
+++ b/inputimeout/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'inputimeout'
 __description__ = 'Multi platform standard input with timeout'
-__url__ = 'http://github.com/johejo/inutimeout'
+__url__ = 'http://github.com/johejo/inputimeout'
 __version__ = '1.0.4'
 __author__ = 'Mitsuo Heijo'
 __author_email__ = 'mitsuo_h@outlook.com'


### PR DESCRIPTION
Hello! I noticed that the URL on the PyPi page was pointing to http://github.com/johejo/inutimeout (no `p`) instead of http://github.com/johejo/inputimeout

This change fixes that if there is another release.